### PR TITLE
Add Deployment manifest using envFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,29 @@ This proxy enables you to:
     v
    Amazon ES (Kibana)
 ```
+
+## Install
+
+```bash
+kubectl create -f kubernetes/namespace.yaml
+kubectl create -f kubernetes/service.yaml
+
+# Use envFrom (>= k8s 1.6)
+kubectl create -f kubernetes/deployment-envFrom.yaml
+
+# or else
+kubectl create -f kubernetes/deployment.yaml
+```
+
+## Environment variables
+
+|Kubernetes Secret name|Key|Description|
+|---|---|---|
+|`aws-signing-proxy`|`AWS_ACCESS_KEY_ID`|AWS access key ID|
+|`aws-signing-proxy`|`AWS_SECRET_ACCESS_KEY`|AWS secret access key|
+|`aws-signing-proxy`|`AWS_REGION`|AWS region|
+|`aws-signing-proxy`|`AWS_SIGN_PROXY_SERVICE_NAME`|AWS service name (e.g., `es` for Amazon ES)|
+|`aws-signing-proxy`|`AWS_SIGN_PROXY_UPSTREAM_HOST`|Upstream endpoint (e.g., `search-foobar-fae9r7u324rhq43hfw89efhwef.ap-northeast-1.es.amazonaws.com` for Amazon ES)|
+|`nginx-basic-auth-proxy`|`BASIC_AUTH_USERNAME`|Nginx basic auth username|
+|`nginx-basic-auth-proxy`|`BASIC_AUTH_PASSWORD`|Nginx basic auth password|
+|`nginx-basic-auth-proxy`|`SERVER_NAME`|Nginx server name|

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ kubectl create -f kubernetes/deployment.yaml
 |`aws-signing-proxy`|`AWS_SECRET_ACCESS_KEY`|AWS secret access key|
 |`aws-signing-proxy`|`AWS_REGION`|AWS region|
 |`aws-signing-proxy`|`AWS_SIGN_PROXY_SERVICE_NAME`|AWS service name (e.g., `es` for Amazon ES)|
-|`aws-signing-proxy`|`AWS_SIGN_PROXY_UPSTREAM_HOST`|Upstream endpoint (e.g., `search-foobar-fae9r7u324rhq43hfw89efhwef.ap-northeast-1.es.amazonaws.com` for Amazon ES)|
+|`aws-signing-proxy`|`AWS_SIGN_PROXY_UPSTREAM_HOST`|Upstream endpoint (e.g., `search-xxx.ap-northeast-1.es.amazonaws.com` for Amazon ES)|
 |`nginx-basic-auth-proxy`|`BASIC_AUTH_USERNAME`|Nginx basic auth username|
 |`nginx-basic-auth-proxy`|`BASIC_AUTH_PASSWORD`|Nginx basic auth password|
 |`nginx-basic-auth-proxy`|`SERVER_NAME`|Nginx server name|

--- a/kubernetes/deployment-envFrom.yaml
+++ b/kubernetes/deployment-envFrom.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: aws-es-auth-proxy
+  namespace: aws-es-auth-proxy
+  labels:
+    name: aws-es-auth-proxy
+    role: web
+spec:
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      name: aws-es-auth-proxy
+      labels:
+        name: aws-es-auth-proxy
+        role: web
+    spec:
+      containers:
+      - image: quay.io/dtan4/aws-sign-proxy
+        name: aws-signing-proxy
+        ports:
+        - containerPort: 8080
+        envFrom:
+        - secretRef:
+            name: aws-signing-proxy
+      - image: quay.io/dtan4/nginx-basic-auth-proxy
+        name: nginx-basic-auth-proxy
+        ports:
+        - containerPort: 80
+        env:
+        - name: PROXY_PASS
+          value: http://localhost:8080/
+        envFrom:
+        - secretRef:
+            name: nginx-basic-auth-proxy


### PR DESCRIPTION
## WHY

Rewriting Deployment manifest to add new environment variables is so troublesome.

## WHAT

Add new manifest using `envFrom`, which allows us to add / delete environment variables without updating manifest file.

## REF

- [Secrets - Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/)